### PR TITLE
Add api CRUD for basic tables

### DIFF
--- a/laravel/app/Http/Controllers/Api/AuthController.php
+++ b/laravel/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Api\BaseController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\User;
+use Validator;
+
+class AuthController extends BaseController
+{
+    /**
+     * Register API function
+     */
+    public function register(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string',
+            'email' => 'required|string|email|unique:users,email',
+            'password' => 'required|string|min:6',
+        ]);
+
+        if($validator->fails()){
+            return $this->sendError('Validation Error.', $validator->errors(), 422);
+        }
+
+        $input = $request->all();
+        $input['password'] = bcrypt($input['password']);
+        $user = User::create($input);
+        $success['token'] = $user->createToken('ipmedth')->plainTextToken;
+        $success['token_type'] = 'Bearer';
+        $success['name'] = $user->name;
+
+        return $this->sendResponse($success, 'User register successfully.');
+    }
+
+    /**
+     * Login API function
+     */
+    public function login(Request $request)
+    {
+        if(Auth::attempt(['email' => $request->email, 'password' => $request->password])){
+            $user = Auth::user();
+            $success['token'] = $user->createToken('ipmedth')->plainTextToken;
+            $success['token_type'] = 'Bearer';
+            $success['name'] = $user->name;
+
+            return $this->sendResponse($success, 'User login successfully.');
+        }
+        else{
+            return $this->sendError('Unauthorised.', ['error'=>'Unauthorised'], 401);
+        }
+    }
+
+    /**
+     * Logout API function
+     */
+    public function logout(Request $request)
+    {
+        // use this to revoke all tokens (logout from all devices)
+        $request->user()->tokens()->delete();
+        // Revoke the token that was used to authenticate the current request
+        // $request->user()->currentAccessToken()->delete();
+        return $this->sendResponse([], 'User logout successfully.');
+    }
+
+    /**
+     * Get authenticated user info
+     */
+    public function getAuthenticatedUser(Request $request)
+    {
+        return $this->sendResponse(Auth::user(), 'User retrieved successfully.');
+    }
+}

--- a/laravel/app/Http/Controllers/Api/BaseController.php
+++ b/laravel/app/Http/Controllers/Api/BaseController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class BaseController extends Controller
+{
+    /**
+     * success response method.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function sendResponse($result, $message)
+    {
+        $response = [
+            'success' => true,
+            'data'    => $result,
+            'message' => $message,
+        ];
+        return response()->json($response, 200);
+    }
+
+    /**
+     * return error response.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function sendError($error, $errorMessages = [], $code = 404)
+    {
+        $response = [
+            'success' => false,
+            'message' => $error,
+        ];
+        if(!empty($errorMessages)){
+            $response['data'] = $errorMessages;
+        }
+        return response()->json($response, $code);
+    }
+}

--- a/laravel/app/Http/Controllers/Api/MeasurementController.php
+++ b/laravel/app/Http/Controllers/Api/MeasurementController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Api\BaseController;
+use App\Http\Resources\Measurement as MeasurementResource;
+use Illuminate\Http\Request;
+use App\Models\Measurement;
+use App\Models\Session;
+use Validator;
+
+class MeasurementController extends BaseController
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $measurements = Measurement::all();
+        return $this->sendResponse(MeasurementResource::collection($measurements), 'All measurements retrieved successfully.');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        // Validate the request
+        $validator = Validator::make($request->all(), [
+            'finger_1' => 'required|json',
+            'finger_2' => 'required|json',
+            'finger_3' => 'required|json',
+            'finger_4' => 'required|json',
+            'finger_5' => 'required|json',
+            'session_id' => 'required|exists:sessions,id',
+        ]);
+        if($validator->fails()){
+            return $this->sendError('Validation Error.', $validator->errors(), 422);
+        }
+
+        // Create new measurement instance
+        $measurement = new Measurement();
+        $measurement->user_id = $request->user()->id;
+        $measurement->session_id = $request->session_id;
+        $measurement->finger_1 = $request->finger_1;
+        $measurement->finger_2 = $request->finger_2;
+        $measurement->finger_3 = $request->finger_3;
+        $measurement->finger_4 = $request->finger_4;
+        $measurement->finger_5 = $request->finger_5;
+
+        $measurement->save();
+
+        return $this->sendResponse(new MeasurementResource($measurement), 'Measurement created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        $measurement = Measurement::find($id);
+        if (is_null($measurement)) {
+            return $this->sendError('Measurement not found.');
+        }
+        return $this->sendResponse(new MeasurementResource($measurement), 'Measurement retrieved successfully.');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        // Get the measurement instance
+        $measurement = Measurement::find($id);
+        if (is_null($measurement)) {
+            return $this->sendError('Measurement not found.');
+        }
+
+        // Validate the request
+        $validator = Validator::make($request->all(), [
+            'finger_1' => 'required|json',
+            'finger_2' => 'required|json',
+            'finger_3' => 'required|json',
+            'finger_4' => 'required|json',
+            'finger_5' => 'required|json',
+            'session_id' => 'required|exists:sessions,id',
+        ]);
+        if($validator->fails()){
+            return $this->sendError('Validation Error.', $validator->errors(), 422);
+        }
+
+        $measurement->update($request->all());
+        return $this->sendResponse(new MeasurementResource($measurement), 'Measurement updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\Measurement  $measurement
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Measurement $measurement)
+    {
+        if (is_null($measurement)) {
+            return $this->sendError('Measurement not found.');
+        }
+        $measurement->delete();
+        return $this->sendResponse([], 'Measurement deleted successfully.');
+    }
+}

--- a/laravel/app/Http/Controllers/Api/PatientController.php
+++ b/laravel/app/Http/Controllers/Api/PatientController.php
@@ -86,6 +86,9 @@ class PatientController extends BaseController
      */
     public function destroy(Patient $patient)
     {
+        if (is_null($patient)) {
+            return $this->sendError('Patient not found.');
+        }
         $patient->delete();
         return $this->sendResponse([], 'Patient deleted successfully.');
     }

--- a/laravel/app/Http/Controllers/Api/PatientController.php
+++ b/laravel/app/Http/Controllers/Api/PatientController.php
@@ -18,7 +18,7 @@ class PatientController extends BaseController
     public function index()
     {
         $patients = Patient::all();
-        return $this->sendResponse(PatientResource::collection($patients), 'Patients retrieved successfully.');
+        return $this->sendResponse(PatientResource::collection($patients), 'All patients retrieved successfully.');
     }
 
     /**
@@ -65,6 +65,7 @@ class PatientController extends BaseController
      */
     public function update(Request $request, Patient $patient)
     {
+        // Validation
         $validator = Validator::make($request->all(), [
             'name' => 'required|string',
             'date_of_birth' => 'date|nullable',

--- a/laravel/app/Http/Controllers/Api/PatientController.php
+++ b/laravel/app/Http/Controllers/Api/PatientController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Api\BaseController;
+use App\Http\Resources\Patient as PatientResource;
+use Illuminate\Http\Request;
+use App\Models\Patient;
+use Validator;
+
+class PatientController extends BaseController
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $patients = Patient::all();
+        return $this->sendResponse(PatientResource::collection($patients), 'Patients retrieved successfully.');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string',
+            'date_of_birth' => 'date|nullable',
+            'email' => 'required|email|unique:patients,email',
+        ]);
+        if($validator->fails()){
+            return $this->sendError('Validation Error.', $validator->errors(), 422);
+        }
+        $patient = Patient::create($request->all());
+        return $this->sendResponse(new PatientResource($patient), 'Patient created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        $patient = Patient::find($id);
+        if (is_null($patient)) {
+            return $this->sendError('Patient not found.');
+        }
+        return $this->sendResponse(new PatientResource($patient), 'Patient retrieved successfully.');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Model\Patient  $patient
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, Patient $patient)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string',
+            'date_of_birth' => 'date|nullable',
+            'email' => 'required|email|unique:patients,email,'.$patient->id,
+        ]);
+        if($validator->fails()){
+            return $this->sendError('Validation Error.', $validator->errors(), 422);
+        }
+
+        $patient->update($request->all());
+        return $this->sendResponse(new PatientResource($patient), 'Patient updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Model\Patient  $patient
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Patient $patient)
+    {
+        $patient->delete();
+        return $this->sendResponse([], 'Patient deleted successfully.');
+    }
+}

--- a/laravel/app/Http/Controllers/Api/SessionController.php
+++ b/laravel/app/Http/Controllers/Api/SessionController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Api\BaseController;
+use App\Http\Resources\Session as SessionResource;
+use Illuminate\Http\Request;
+use App\Models\Session;
+use Validator;
+
+class SessionController extends BaseController
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $sessions = Session::all();
+        return $this->sendResponse(SessionResource::collection($sessions), 'All sessions retrieved successfully.');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        // Validation
+        $validator = Validator::make($request->all(), [
+            'date' => 'required|date',
+            'patient_id' => 'required|exists:patients,id',
+        ]);
+
+        if($validator->fails()){
+            return $this->sendError('Validation Error.', $validator->errors(), 422);
+        }
+
+        // Store a new session instance
+        $session = new Session();
+        $session->date = $request->date;
+        $session->user_id = $request->user()->id;
+        $session->patient_id = $request->patient_id;
+
+        $session->save();
+
+        return $this->sendResponse(new SessionResource($session), 'Session created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        $session = Session::find($id);
+        if (is_null($session)) {
+            return $this->sendError('Session not found.');
+        }
+        return $this->sendResponse(new SessionResource($session), 'Session retrieved successfully.');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        // Get the session instance
+        $session = Session::find($id);
+        if (is_null($session)) {
+            return $this->sendError('Session not found.');
+        }
+
+        // Validation
+        $validator = Validator::make($request->all(), [
+            'date' => 'required|date',
+            'patient_id' => 'required|exists:patients,id',
+        ]);
+        if($validator->fails()){
+            return $this->sendError('Validation Error.', $validator->errors(), 422);
+        }
+
+        $session->update($request->all());
+        return $this->sendResponse(new SessionResource($session), 'Session updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\Session  $session
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Session $session)
+    {
+        if (is_null($session)) {
+            return $this->sendError('Session not found.');
+        }
+        $session->delete();
+        return $this->sendResponse([], 'Session deleted successfully.');
+    }
+}

--- a/laravel/app/Http/Kernel.php
+++ b/laravel/app/Http/Kernel.php
@@ -39,7 +39,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],

--- a/laravel/app/Http/Resources/Measurement.php
+++ b/laravel/app/Http/Resources/Measurement.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Measurement extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'session_id' => $this->session_id,
+            'finger_1' => $this->finger_1,
+            'finger_2' => $this->finger_2,
+            'finger_3' => $this->finger_3,
+            'finger_4' => $this->finger_4,
+            'finger_5' => $this->finger_5,
+            'created_at' => $this->created_at->format('d-m-Y H:m:s'),
+            'updated_at' => $this->updated_at->format('d-m-Y H:m:s'),
+        ];
+    }
+}

--- a/laravel/app/Http/Resources/Patient.php
+++ b/laravel/app/Http/Resources/Patient.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Patient extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'date_of_birth' => $this->date_of_birth->format('d-m-Y'),
+            'email' => $this->email,
+            'created_at' => $this->created_at->format('d-m-Y H:m:s'),
+            'updated_at' => $this->updated_at->format('d-m-Y H:m:s'),
+        ];
+    }
+}

--- a/laravel/app/Http/Resources/Patient.php
+++ b/laravel/app/Http/Resources/Patient.php
@@ -19,6 +19,7 @@ class Patient extends JsonResource
             'name' => $this->name,
             'date_of_birth' => $this->date_of_birth->format('d-m-Y'),
             'email' => $this->email,
+            'sessions' => Session::collection($this->sessions),
             'created_at' => $this->created_at->format('d-m-Y H:m:s'),
             'updated_at' => $this->updated_at->format('d-m-Y H:m:s'),
         ];

--- a/laravel/app/Http/Resources/Session.php
+++ b/laravel/app/Http/Resources/Session.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Session extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'date' => $this->date->format('d-m-Y'),
+            'user_id' => $this->user_id,
+            'patient_id' => $this->patient_id,
+            'measurements' => Measurement::collection($this->measurements),
+            'created_at' => $this->created_at->format('d-m-Y H:m:s'),
+            'updated_at' => $this->updated_at->format('d-m-Y H:m:s'),
+        ];
+    }
+}

--- a/laravel/app/Models/Measurement.php
+++ b/laravel/app/Models/Measurement.php
@@ -15,20 +15,25 @@ class Measurement extends Model
      * @var array
      */
     protected $fillable = [
-        'patient_id',
         'user_id',
+        'session_id',
+        'finger_1',
+        'finger_2',
+        'finger_3',
+        'finger_4',
+        'finger_5',
     ];
 
     /**
      * Relationships
      */
-    public function patient()
-    {
-        return $this->belongsTo(Patient::class);
-    }
-
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function session()
+    {
+        return $this->belongsTo(Session::class);
     }
 }

--- a/laravel/app/Models/Measurement.php
+++ b/laravel/app/Models/Measurement.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Measurement extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'patient_id',
+        'user_id',
+    ];
+
+    /**
+     * Relationships
+     */
+    public function patient()
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/laravel/app/Models/Patient.php
+++ b/laravel/app/Models/Patient.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Patient extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'date_of_birth',
+        'email',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'date_of_birth' => 'datetime',
+    ];
+
+    /**
+     * Relationships
+     */
+    public function measurements()
+    {
+        return $this->hasMany(Measurement::class);
+    }
+}

--- a/laravel/app/Models/Patient.php
+++ b/laravel/app/Models/Patient.php
@@ -32,8 +32,8 @@ class Patient extends Model
     /**
      * Relationships
      */
-    public function measurements()
+    public function sessions()
     {
-        return $this->hasMany(Measurement::class);
+        return $this->hasMany(Session::class);
     }
 }

--- a/laravel/app/Models/Session.php
+++ b/laravel/app/Models/Session.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Session extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'date',
+        'user_id',
+        'patient_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'date' => 'date',
+    ];
+
+    /**
+     * Relationships
+     */
+    public function measurements()
+    {
+        return $this->hasMany(Measurement::class);
+    }
+}

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -8,7 +8,7 @@
         "php": "^8.0.2",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.11",
-        "laravel/sanctum": "^2.14.1",
+        "laravel/sanctum": "^2.15",
         "laravel/tinker": "^2.7",
         "pavel-mironchik/laravel-backup-panel": "^2.2",
         "spatie/laravel-backup": "^8.1"

--- a/laravel/composer.lock
+++ b/laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e86a6eb325ac1e7294eb05d224dbe70b",
+    "content-hash": "d4649f4a981127df96827a86926aabc9",
     "packages": [
         {
             "name": "brick/math",

--- a/laravel/database/migrations/2022_05_17_181410_create_patients_table.php
+++ b/laravel/database/migrations/2022_05_17_181410_create_patients_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('patients', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->date('date_of_birth')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('patients');
+    }
+};

--- a/laravel/database/migrations/2022_05_17_181412_create_sessions_table.php
+++ b/laravel/database/migrations/2022_05_17_181412_create_sessions_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->id();
+            $table->date('date');
+            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('patient_id')->constrained('patients');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sessions');
+    }
+};

--- a/laravel/database/migrations/2022_05_17_181448_create_measurements_table.php
+++ b/laravel/database/migrations/2022_05_17_181448_create_measurements_table.php
@@ -15,8 +15,13 @@ return new class extends Migration
     {
         Schema::create('measurements', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('patient_id')->constrained('patients');
             $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('session_id')->constrained('sessions')->onDelete('cascade');
+            $table->json('finger_1');
+            $table->json('finger_2');
+            $table->json('finger_3');
+            $table->json('finger_4');
+            $table->json('finger_5');
             $table->timestamps();
         });
     }

--- a/laravel/database/migrations/2022_05_17_181448_create_measurements_table.php
+++ b/laravel/database/migrations/2022_05_17_181448_create_measurements_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('measurements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('patient_id')->constrained('patients');
+            $table->foreignId('user_id')->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('measurements');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -3,6 +3,8 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
+use App\Http\Controllers\Api;
+
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -14,6 +16,30 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+/*
+* Routes for authentication
+*/
+Route::controller(Api\AuthController::class)->prefix('auth')->group(function() {
+    Route::post('register', 'register');
+    Route::post('login', 'login');
+    Route::middleware('auth:sanctum')->group(function() {
+        Route::post('logout', 'logout');
+        Route::get('user', 'getAuthenticatedUser');
+    });
+});
+
+/*
+* Protected routes
+*/
+Route::middleware('auth:sanctum')->group( function () {
+    Route::apiResource('patients', Api\PatientController::class);
+});
+
+/**
+ * Fallback function
+ * Keep this at the end of the file
+ */
+Route::fallback(function(){
+    return response()->json([
+        'message' => 'Page Not Found. If error persists, contact info@ipmedth.nl'], 404);
 });

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -33,6 +33,7 @@ Route::controller(Api\AuthController::class)->prefix('auth')->group(function() {
 */
 Route::middleware('auth:sanctum')->group( function () {
     Route::apiResource('patients', Api\PatientController::class);
+    Route::apiResource('sessions', Api\SessionController::class);
 });
 
 /**

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -33,6 +33,7 @@ Route::controller(Api\AuthController::class)->prefix('auth')->group(function() {
 */
 Route::middleware('auth:sanctum')->group( function () {
     Route::apiResource('patients', Api\PatientController::class);
+    Route::apiResource('measurements', Api\MeasurementController::class);
     Route::apiResource('sessions', Api\SessionController::class);
 });
 

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -23,3 +23,32 @@ server {
         gzip_static on;
     }
 }
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443;
+
+    root /var/www/public;
+    index index.php index.html;
+
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+        gzip_static on;
+    }
+
+    ssl_certificate /etc/letsencrypt/live/npm-13/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/npm-13/privkey.pem;
+}


### PR DESCRIPTION
This PR will add the basic CRUD for the following models:
- Patients
- Sessions
- Measurements

Support for auth api routes:
- login
- register
- logout
- user account info
