### PR TITLE
Add image to measurements

### DIFF
--- a/laravel/app/Http/Controllers/Api/BaseController.php
+++ b/laravel/app/Http/Controllers/Api/BaseController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\Request;
 
 /**
@@ -79,5 +80,13 @@ class BaseController extends Controller
             $response['data'] = $errorMessages;
         }
         return response()->json($response, $code);
+    }
+
+    /**
+     * Remove old images from storage
+     */
+    protected function deleteImage($type, $imageName)
+    {
+        Storage::disk('local')->delete('private/images/'.$type.'/'.$imageName);
     }
 }

--- a/laravel/app/Http/Requests/StoreMeasurementRequest.php
+++ b/laravel/app/Http/Requests/StoreMeasurementRequest.php
@@ -39,6 +39,7 @@ class StoreMeasurementRequest extends FormRequest
      * @OA\Property(type="string", example="{}", description="Ring finger", property="finger_ring"),
      * @OA\Property(type="string", example="{}", description="Little finger", property="finger_pink"),
      * @OA\Property(type="string", example="{}", description="Wrist", property="wrist"),
+     * @OA\Property(type="string", format="binary", example="file", description="Photo of the hand the was made", property="image"),
      */
     public function rules()
     {
@@ -57,6 +58,7 @@ class StoreMeasurementRequest extends FormRequest
             'finger_ring' => 'required|json',
             'finger_pink' => 'required|json',
             'wrist' => 'required|json',
+            'image' => 'image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ];
     }
 

--- a/laravel/app/Http/Requests/UpdateMeasurementRequest.php
+++ b/laravel/app/Http/Requests/UpdateMeasurementRequest.php
@@ -39,6 +39,7 @@ class UpdateMeasurementRequest extends FormRequest
      * @OA\Property(type="string", example="{}", description="Ring finger", property="finger_ring"),
      * @OA\Property(type="string", example="{}", description="Little finger", property="finger_pink"),
      * @OA\Property(type="string", example="{}", description="Wrist", property="wrist"),
+     * @OA\Property(type="string", format="binary", example="file", description="Photo of the hand the was made", property="image"),
      */
     public function rules()
     {
@@ -57,6 +58,7 @@ class UpdateMeasurementRequest extends FormRequest
             'finger_ring' => 'required|json',
             'finger_pink' => 'required|json',
             'wrist' => 'required|json',
+            'image' => 'image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ];
     }
 

--- a/laravel/app/Http/Resources/Measurement.php
+++ b/laravel/app/Http/Resources/Measurement.php
@@ -27,6 +27,7 @@ class Measurement extends JsonResource
             'finger_ring' => $this->finger_ring,
             'finger_pink' => $this->finger_pink,
             'wrist' => $this->wrist,
+            'image' => $this->image,
             'created_at' => $this->created_at->format('d-m-Y H:m:s'),
             'updated_at' => $this->updated_at->format('d-m-Y H:m:s'),
         ];

--- a/laravel/app/Models/Measurement.php
+++ b/laravel/app/Models/Measurement.php
@@ -26,6 +26,7 @@ class Measurement extends Model
         'finger_ring',
         'finger_pink',
         'wrist',
+        'image',
     ];
 
     /**

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -8,6 +8,7 @@
         "php": "^8.0.2",
         "darkaonline/l5-swagger": "^8.3",
         "guzzlehttp/guzzle": "^7.2",
+        "intervention/image": "^2.7",
         "laravel/framework": "^9.11",
         "laravel/sanctum": "^2.15",
         "laravel/tinker": "^2.7",

--- a/laravel/composer.lock
+++ b/laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3e6084d406f000dbee0cf051b93e0a5",
+    "content-hash": "b3ce96c3f119a7fa70e19d98fb506bc9",
     "packages": [
         {
             "name": "brick/math",
@@ -1043,6 +1043,90 @@
                 }
             ],
             "time": "2022-03-20T21:55:58+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/04be355f8d6734c826045d02a1079ad658322dad",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1 || ^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^7.5.15"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/2.7.2"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-05-21T17:30:32+00:00"
         },
         {
             "name": "laravel/framework",
@@ -8644,5 +8728,5 @@
         "php": "^8.0.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/laravel/config/app.php
+++ b/laravel/config/app.php
@@ -185,6 +185,7 @@ return [
         /*
          * Package Service Providers...
          */
+        Intervention\Image\ImageServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -211,6 +212,7 @@ return [
 
     'aliases' => Facade::defaultAliases()->merge([
         // 'ExampleClass' => App\Example\ExampleClass::class,
+        'Image' => Intervention\Image\Facades\Image::class,
     ])->toArray(),
 
 ];

--- a/laravel/database/factories/MeasurementFactory.php
+++ b/laravel/database/factories/MeasurementFactory.php
@@ -30,6 +30,7 @@ class MeasurementFactory extends Factory
             'finger_ring' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
             'finger_pink' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
             'wrist' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
+            'image' => $this->faker->image('public/storage/images',640,480, null, false),
         ];
     }
 }

--- a/laravel/database/factories/MeasurementFactory.php
+++ b/laravel/database/factories/MeasurementFactory.php
@@ -30,7 +30,7 @@ class MeasurementFactory extends Factory
             'finger_ring' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
             'finger_pink' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
             'wrist' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
-            'image' => $this->faker->image('public/storage/images',640,480, null, false),
+            'image' => $this->faker->image(storage_path('images'), 640, 480, null, false),
         ];
     }
 }

--- a/laravel/database/factories/MeasurementFactory.php
+++ b/laravel/database/factories/MeasurementFactory.php
@@ -30,7 +30,7 @@ class MeasurementFactory extends Factory
             'finger_ring' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
             'finger_pink' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
             'wrist' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
-            'image' => $this->faker->image(storage_path('images'), 640, 480, null, false),
+            'image' => $this->faker->image(storage_path('app/public/images'), 640, 480, null, false),
         ];
     }
 }

--- a/laravel/database/factories/MeasurementFactory.php
+++ b/laravel/database/factories/MeasurementFactory.php
@@ -30,7 +30,6 @@ class MeasurementFactory extends Factory
             'finger_ring' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
             'finger_pink' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
             'wrist' => json_encode(['thing' => rand(11,99), 'other' => rand(11,99)]),
-            'image' => $this->faker->image(storage_path('app/public/images'), 640, 480, null, false),
         ];
     }
 }

--- a/laravel/database/migrations/2022_05_17_181448_create_measurements_table.php
+++ b/laravel/database/migrations/2022_05_17_181448_create_measurements_table.php
@@ -26,6 +26,7 @@ return new class extends Migration
             $table->json('finger_ring');
             $table->json('finger_pink');
             $table->json('wrist');
+            $table->string('image')->nullable();
             $table->timestamps();
         });
     }

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -17,6 +17,15 @@ Route::get('/', function () {
     return view('welcome');
 });
 
+// Get images from storage
+Route::get('/images/{type}/{file}', [ function ($type, $file) {
+    $path = storage_path('app/private/images/'.$type.'/'.$file);
+    if (file_exists($path)) {
+        return response()->file($path, array('Content-Type' => 'image/jpeg'));
+    }
+    abort(404);
+}]);
+
 Route::get('/phpinfo', function () {
     return phpinfo();
 });

--- a/laravel/storage/api-docs/api-docs.json
+++ b/laravel/storage/api-docs/api-docs.json
@@ -194,7 +194,7 @@
                     "Measurements"
                 ],
                 "summary": "Get a measurement",
-                "description": "Returns a measurement",
+                "description": "Returns a measurement. Get the related image by calling the image endpoint: https://ipmedth.nl/images/measurements/{filename}",
                 "operationId": "GetMeasurement",
                 "parameters": [
                     {
@@ -723,6 +723,12 @@
                         "description": "Wrist",
                         "type": "string",
                         "example": "{}"
+                    },
+                    "image": {
+                        "description": "Photo of the hand the was made",
+                        "type": "string",
+                        "format": "binary",
+                        "example": "file"
                     }
                 },
                 "type": "object"
@@ -838,6 +844,12 @@
                         "description": "Wrist",
                         "type": "string",
                         "example": "{}"
+                    },
+                    "image": {
+                        "description": "Photo of the hand the was made",
+                        "type": "string",
+                        "format": "binary",
+                        "example": "file"
                     }
                 },
                 "type": "object"

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -5,6 +5,8 @@ server {
     root /var/www/public;
     index index.php index.html;
 
+    client_max_body_size 100M;
+
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
 
@@ -30,6 +32,8 @@ server {
 
     root /var/www/public;
     index index.php index.html;
+
+    client_max_body_size 100M;
 
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;


### PR DESCRIPTION
You can now store the image of a measurement to the database. These images cannot be accessed publicly, but only via a separate url.