### PR TITLE
Make personal teams optional

### DIFF
--- a/laravel/app/Actions/Fortify/CreateNewUser.php
+++ b/laravel/app/Actions/Fortify/CreateNewUser.php
@@ -35,7 +35,7 @@ class CreateNewUser implements CreatesNewUsers
                 'email' => $input['email'],
                 'password' => Hash::make($input['password']),
             ]), function (User $user) {
-                $this->createTeam($user);
+                // $this->createTeam($user);
             });
         });
     }

--- a/laravel/app/Http/Kernel.php
+++ b/laravel/app/Http/Kernel.php
@@ -63,5 +63,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'team' => \App\Http\Middleware\EnsureHasTeam::class,
     ];
 }

--- a/laravel/app/Http/Middleware/EnsureHasTeam.php
+++ b/laravel/app/Http/Middleware/EnsureHasTeam.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureHasTeam
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (!auth()->user()->isMemberOfATeam()) {
+            return redirect()->route('teams.create');
+        }
+        $this->ensureUserHasCurrentTeamSet();
+        return $next($request);
+    }
+
+    protected function ensureUserHasCurrentTeamSet(): void
+    {
+        if (is_null(auth()->user()->current_team_id)) {
+            $user = auth()->user();
+            $user->current_team_id = $user->allTeams()->first()->id;
+            $user->save();
+        }
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -11,13 +11,17 @@ use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Jetstream\HasTeams;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
+use App\Traits\HasNoPersonalTeam;
 
 class User extends Authenticatable
 {
     use HasApiTokens;
     use HasFactory;
     use HasProfilePhoto;
-    use HasTeams;
+    use HasNoPersonalTeam, HasTeams {
+        HasNoPersonalTeam::ownsTeam insteadof HasTeams;
+        HasNoPersonalTeam::isCurrentTeam insteadof HasTeams;
+    }
     use Notifiable;
     use TwoFactorAuthenticatable;
     use HasRoles;

--- a/laravel/app/Traits/HasNoPersonalTeam.php
+++ b/laravel/app/Traits/HasNoPersonalTeam.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Traits;
+
+trait HasNoPersonalTeam
+{
+
+    /**
+     * Determine if the user owns the given team.
+     *
+     * @param  mixed  $team
+     * @return bool
+     */
+    public function ownsTeam($team)
+    {
+        // return $this->id == $team->user_id;
+        return $this->id == optional($team)->user_id;
+    }
+
+    /**
+     * Determine if the given team is the current team.
+     *
+     * @param  mixed  $team
+     * @return bool
+     */
+    public function isCurrentTeam($team)
+    {
+        return optional($team)->id === $this->currentTeam->id;
+    }
+
+    /**
+     * Determine if the user is apart of any team.
+     *
+     * @param  mixed  $team
+     * @return bool
+     */
+    public function isMemberOfATeam(): bool
+    {
+        return (bool) ($this->teams()->count() || $this->ownedTeams()->count());
+    }
+}

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -16,7 +16,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             PermissionTableSeeder::class,
-            TeamTableSeeder::class,
+            // TeamTableSeeder::class,
             // Add user seeder
             UserTableSeeder::class,
 

--- a/laravel/resources/views/navigation-menu.blade.php
+++ b/laravel/resources/views/navigation-menu.blade.php
@@ -20,7 +20,7 @@
 
             <div class="hidden sm:flex sm:items-center sm:ml-6">
                 <!-- Teams Dropdown -->
-                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
+                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures() && Auth::user()->isMemberOfATeam())
                     <div class="ml-3 relative">
                         <x-jet-dropdown align="right" width="60">
                             <x-slot name="trigger">
@@ -180,7 +180,7 @@
                 </form>
 
                 <!-- Team Management -->
-                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
+                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures() && Auth::user()->isMemberOfATeam())
                     <div class="border-t border-gray-200"></div>
 
                     <div class="block px-4 py-2 text-xs text-gray-400">

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -29,11 +29,8 @@ Route::get('/images/{type}/{file}', [ function ($type, $file) {
 Route::get('/phpinfo', function () {
     return phpinfo();
 });
-Route::middleware([
-    'auth:sanctum',
-    config('jetstream.auth_session'),
-    'verified'
-])->group(function () {
+
+Route::middleware(['auth:sanctum', 'verified', 'team'])->group(function () {
     Route::get('/dashboard', function () {
         return view('dashboard');
     })->name('dashboard');


### PR DESCRIPTION
By default, laravel jetstream wants to create a personal team per new account, that is superfluous in this case and therefore made it optional.